### PR TITLE
Fix single contstructor decoders

### DIFF
--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -39,7 +39,7 @@ instance HasDecoderRef ElmDatatype where
 instance HasDecoder ElmConstructor where
   render (NamedConstructor name value) = do
     dv <- render value
-    return $ "decode" <+> stext name <$$> indent 4 dv
+    return $ dv <$$> indent 4 ("|> map" <+> stext name)
   render (RecordConstructor name value) = do
     dv <- render value
     return $ "decode" <+> stext name <$$> indent 4 dv

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -37,6 +37,8 @@ instance HasDecoderRef ElmDatatype where
   renderRef (ElmPrimitive primitive) = renderRef primitive
 
 instance HasDecoder ElmConstructor where
+  render (NamedConstructor name ElmEmpty) =
+    return $ "succeed" <+> stext name
   render (NamedConstructor name value) = do
     dv <- render value
     return $ dv <$$> indent 4 ("|> map" <+> stext name)

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -38,6 +38,9 @@ instance HasEncoder ElmConstructor where
   render (NamedConstructor _name ElmEmpty) =
     return $ "Json.Encode.list []"
 
+  render (NamedConstructor _name (ElmPrimitiveRef EUnit)) =
+    return $ "Json.Encode.list []"
+
   -- Single constructor, multiple values: create array with values
   render (NamedConstructor name value@(Values _ _)) = do
     let ps = constructorParameters 0 value

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -49,8 +49,12 @@ instance HasEncoder ElmConstructor where
       (nest 4 $ cs <$$> nest 4 ("Json.Encode.list" <$$> "[" <+> dv <$$> "]"))
 
   -- Single constructor, one value: skip constructor and render just the value
-  render (NamedConstructor _name val) =
-    render val
+  render (NamedConstructor name value) = do
+    dv <- render value
+
+    let cs = stext name <+> "y0 ->"
+    return . nest 4 $ "case x of" <$$>
+      nest 4 (cs <$$> nest 4 dv <+> "y0")
 
 
   render (RecordConstructor _ value) = do

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -68,6 +68,9 @@ newtype Useless =
 data Unit = Unit
   deriving (Generic, ElmType)
 
+newtype Wrapper = Wrapper Int
+  deriving (Generic, ElmType)
+
 newtype FavoritePlaces = FavoritePlaces
   { positionsByUser :: Map String [Position]
   } deriving (Generic, ElmType)
@@ -147,6 +150,12 @@ toElmTypeSpec =
         defaultOptions
         (Proxy :: Proxy Unit)
         "test/UnitType.elm"
+    it "toElmTypeSource Wrapper" $
+      shouldMatchTypeSource
+        (unlines ["module WrapperType exposing (..)", "", "", "%s"])
+        defaultOptions
+        (Proxy :: Proxy Wrapper)
+        "test/WrapperType.elm"
     it "toElmTypeSource FavoritePlaces" $
       shouldMatchTypeSource
         (unlines
@@ -354,6 +363,21 @@ toElmDecoderSpec =
         defaultOptions
         (Proxy :: Proxy Unit)
         "test/UnitDecoder.elm"
+    it "toElmDecoderSource Wrapper" $
+      shouldMatchDecoderSource
+        (unlines
+           [ "module WrapperDecoder exposing (..)"
+           , ""
+           , "import Json.Decode exposing (..)"
+           , "import Json.Decode.Pipeline exposing (..)"
+           , "import WrapperType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Wrapper)
+        "test/WrapperDecoder.elm"
     describe "Convert to Elm decoder references." $ do
       it "toElmDecoderRef Post" $
         toElmDecoderRef (Proxy :: Proxy Post) `shouldBe` "decodePost"
@@ -514,6 +538,20 @@ toElmEncoderSpec =
         defaultOptions
         (Proxy :: Proxy Unit)
         "test/UnitEncoder.elm"
+    it "toElmEncoderSourceWithOptions Wrapper" $
+      shouldMatchEncoderSource
+        (unlines
+           [ "module WrapperEncoder exposing (..)"
+           , ""
+           , "import Json.Encode"
+           , "import WrapperType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Wrapper)
+        "test/WrapperEncoder.elm"
     describe "Convert to Elm encoder references." $ do
       it "toElmEncoderRef Post" $
         toElmEncoderRef (Proxy :: Proxy Post) `shouldBe` "encodePost"

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -65,6 +65,9 @@ newtype Useless =
   Useless ()
   deriving (Generic, ElmType)
 
+data Unit = Unit
+  deriving (Generic, ElmType)
+
 newtype FavoritePlaces = FavoritePlaces
   { positionsByUser :: Map String [Position]
   } deriving (Generic, ElmType)
@@ -330,6 +333,21 @@ toElmDecoderSpec =
         defaultOptions
         (Proxy :: Proxy Useless)
         "test/UselessDecoder.elm"
+    it "toElmDecoderSource Unit" $
+      shouldMatchDecoderSource
+        (unlines
+           [ "module UnitDecoder exposing (..)"
+           , ""
+           , "import Json.Decode exposing (..)"
+           , "import Json.Decode.Pipeline exposing (..)"
+           , "import UnitType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Unit)
+        "test/UnitDecoder.elm"
     describe "Convert to Elm decoder references." $ do
       it "toElmDecoderRef Post" $
         toElmDecoderRef (Proxy :: Proxy Post) `shouldBe` "decodePost"

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -480,6 +480,34 @@ toElmEncoderSpec =
         defaultOptions
         (Proxy :: Proxy Monstrosity)
         "test/MonstrosityEncoder.elm"
+    it "toElmEncoderSourceWithOptions Useless" $
+      shouldMatchEncoderSource
+        (unlines
+           [ "module UselessEncoder exposing (..)"
+           , ""
+           , "import Json.Encode"
+           , "import UselessType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Useless)
+        "test/UselessEncoder.elm"
+    it "toElmEncoderSourceWithOptions Unit" $
+      shouldMatchEncoderSource
+        (unlines
+           [ "module UnitEncoder exposing (..)"
+           , ""
+           , "import Json.Encode"
+           , "import UnitType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy Unit)
+        "test/UnitEncoder.elm"
     describe "Convert to Elm encoder references." $ do
       it "toElmEncoderRef Post" $
         toElmEncoderRef (Proxy :: Proxy Post) `shouldBe` "encodePost"

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -141,6 +141,12 @@ toElmTypeSpec =
         defaultOptions
         (Proxy :: Proxy Useless)
         "test/UselessType.elm"
+    it "toElmTypeSource Unit" $
+      shouldMatchTypeSource
+        (unlines ["module UnitType exposing (..)", "", "", "%s"])
+        defaultOptions
+        (Proxy :: Proxy Unit)
+        "test/UnitType.elm"
     it "toElmTypeSource FavoritePlaces" $
       shouldMatchTypeSource
         (unlines

--- a/test/UnitDecoder.elm
+++ b/test/UnitDecoder.elm
@@ -1,0 +1,10 @@
+module UnitDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import UnitType exposing (..)
+
+
+decodeUnit : Decoder Unit
+decodeUnit =
+    succeed Unit

--- a/test/UnitEncoder.elm
+++ b/test/UnitEncoder.elm
@@ -1,0 +1,9 @@
+module UnitEncoder exposing (..)
+
+import Json.Encode
+import UnitType exposing (..)
+
+
+encodeUnit : Unit -> Json.Encode.Value
+encodeUnit x =
+    Json.Encode.list []

--- a/test/UnitType.elm
+++ b/test/UnitType.elm
@@ -1,0 +1,5 @@
+module UnitType exposing (..)
+
+
+type Unit
+    = Unit

--- a/test/UselessDecoder.elm
+++ b/test/UselessDecoder.elm
@@ -7,5 +7,5 @@ import UselessType exposing (..)
 
 decodeUseless : Decoder Useless
 decodeUseless =
-    decode Useless
-        (succeed ())
+    (succeed ())
+        |> map Useless

--- a/test/UselessEncoder.elm
+++ b/test/UselessEncoder.elm
@@ -1,0 +1,9 @@
+module UselessEncoder exposing (..)
+
+import Json.Encode
+import UselessType exposing (..)
+
+
+encodeUseless : Useless -> Json.Encode.Value
+encodeUseless x =
+    Json.Encode.list []

--- a/test/WrapperDecoder.elm
+++ b/test/WrapperDecoder.elm
@@ -1,0 +1,11 @@
+module WrapperDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import WrapperType exposing (..)
+
+
+decodeWrapper : Decoder Wrapper
+decodeWrapper =
+    int
+        |> map Wrapper

--- a/test/WrapperEncoder.elm
+++ b/test/WrapperEncoder.elm
@@ -1,0 +1,11 @@
+module WrapperEncoder exposing (..)
+
+import Json.Encode
+import WrapperType exposing (..)
+
+
+encodeWrapper : Wrapper -> Json.Encode.Value
+encodeWrapper x =
+    case x of
+        Wrapper y0 ->
+            Json.Encode.int y0

--- a/test/WrapperType.elm
+++ b/test/WrapperType.elm
@@ -1,0 +1,5 @@
+module WrapperType exposing (..)
+
+
+type Wrapper
+    = Wrapper Int


### PR DESCRIPTION
# This is dependant and based on #2. Please merge it first!

Some Elm decoders and encoders from Haskell newtype types did not compile. This commit fixes some cases that I found. The newly produced Elm code might not be the most idiomatic but it gets the job done.

I expect there might be other cases we're not yet aware of. The problem is not just generating any decoder encoder for a certain type, but one compatible with what Aeson encoders and decoders are doing. It would be great to be able to do a quick-check based roundtrip: `Aeson.toJSON to Elm.decode to Elm encode to Aeson.decode`.