### PR TITLE
Remove dependency on elm Exts module

### DIFF
--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -151,7 +151,7 @@ instance HasEncoderRef ElmPrimitive where
   renderRef (ETuple2 x y) = do
     dx <- renderRef x
     dy <- renderRef y
-    return . parens $ "Tuple.mapFirst" <+> parens dx <+> ">> Tuple.mapSecond" <+> parens dy <+> ">> (\\( x, y ) -> Json.Encode.list [ x, y ])" <+> ">> Json.Encode.list"
+    return . parens $ "Tuple.mapFirst" <+> parens dx <+> ">> Tuple.mapSecond" <+> parens dy <+> ">> (\\( x, y ) -> Json.Encode.list [ x, y ])"
   renderRef (EDict k v) = do
     dk <- renderRef k
     dv <- renderRef v

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -151,13 +151,12 @@ instance HasEncoderRef ElmPrimitive where
   renderRef (ETuple2 x y) = do
     dx <- renderRef x
     dy <- renderRef y
-    require "Exts.Json.Encode"
-    return . parens $ "Exts.Json.Encode.tuple2" <+> dx <+> dy
+    return . parens $ "Tuple.mapFirst" <+> parens dx <+> ">> Tuple.mapSecond" <+> parens dy <+> ">> (\\( x, y ) -> Json.Encode.list [ x, y ])" <+> ">> Json.Encode.list"
   renderRef (EDict k v) = do
     dk <- renderRef k
     dv <- renderRef v
-    require "Exts.Json.Encode"
-    return . parens $ "Exts.Json.Encode.dict" <+> dk <+> dv
+    require "Dict"
+    return . parens $ "Dict.toList >> List.map" <+> parens ("Tuple.mapFirst" <+> parens dk <+> ">> Tuple.mapSecond" <+> parens dv <+> ">> (\\( x, y ) -> Json.Encode.list [ x, y ])") <+> ">> Json.Encode.list"
 
 toElmEncoderRefWith
   :: ElmType a

--- a/test/CommentDecoder.elm
+++ b/test/CommentDecoder.elm
@@ -1,8 +1,6 @@
 module CommentDecoder exposing (..)
 
 import CommentType exposing (..)
-import Dict
-import Exts.Json.Decode exposing (..)
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
 

--- a/test/CommentDecoderWithOptions.elm
+++ b/test/CommentDecoderWithOptions.elm
@@ -2,7 +2,6 @@ module CommentDecoderWithOptions exposing (..)
 
 import CommentType exposing (..)
 import Dict
-import Exts.Json.Decode exposing (..)
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
 

--- a/test/CommentEncoder.elm
+++ b/test/CommentEncoder.elm
@@ -9,7 +9,7 @@ encodeComment x =
     Json.Encode.object
         [ ( "postId", Json.Encode.int x.postId )
         , ( "text", Json.Encode.string x.text )
-        , ( "mainCategories", (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.string) >> (\( x, y ) -> Json.Encode.list [ x, y ]) >> Json.Encode.list) x.mainCategories )
+        , ( "mainCategories", (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.string) >> (\( x, y ) -> Json.Encode.list [ x, y ])) x.mainCategories )
         , ( "published", Json.Encode.bool x.published )
         , ( "created", (Json.Encode.string << toString) x.created )
         , ( "tags", (Dict.toList >> List.map (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.int) >> (\( x, y ) -> Json.Encode.list [ x, y ])) >> Json.Encode.list) x.tags )

--- a/test/CommentEncoder.elm
+++ b/test/CommentEncoder.elm
@@ -1,7 +1,6 @@
 module CommentEncoder exposing (..)
 
 import CommentType exposing (..)
-import Exts.Json.Encode exposing (..)
 import Json.Encode
 
 
@@ -10,8 +9,8 @@ encodeComment x =
     Json.Encode.object
         [ ( "postId", Json.Encode.int x.postId )
         , ( "text", Json.Encode.string x.text )
-        , ( "mainCategories", (Exts.Json.Encode.tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
+        , ( "mainCategories", (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.string) >> (\( x, y ) -> Json.Encode.list [ x, y ]) >> Json.Encode.list) x.mainCategories )
         , ( "published", Json.Encode.bool x.published )
         , ( "created", (Json.Encode.string << toString) x.created )
-        , ( "tags", (Exts.Json.Encode.dict Json.Encode.string Json.Encode.int) x.tags )
+        , ( "tags", (Dict.toList >> List.map (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.int) >> (\( x, y ) -> Json.Encode.list [ x, y ])) >> Json.Encode.list) x.tags )
         ]

--- a/test/CommentEncoderWithOptions.elm
+++ b/test/CommentEncoderWithOptions.elm
@@ -9,7 +9,7 @@ encodeComment x =
     Json.Encode.object
         [ ( "commentPostId", Json.Encode.int x.postId )
         , ( "commentText", Json.Encode.string x.text )
-        , ( "commentMainCategories", (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.string) >> (\( x, y ) -> Json.Encode.list [ x, y ]) >> Json.Encode.list) x.mainCategories )
+        , ( "commentMainCategories", (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.string) >> (\( x, y ) -> Json.Encode.list [ x, y ])) x.mainCategories )
         , ( "commentPublished", Json.Encode.bool x.published )
         , ( "commentCreated", (Json.Encode.string << toString) x.created )
         , ( "commentTags", (Dict.toList >> List.map (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.int) >> (\( x, y ) -> Json.Encode.list [ x, y ])) >> Json.Encode.list) x.tags )

--- a/test/CommentEncoderWithOptions.elm
+++ b/test/CommentEncoderWithOptions.elm
@@ -1,7 +1,6 @@
 module CommentEncoderWithOptions exposing (..)
 
 import CommentType exposing (..)
-import Exts.Json.Encode exposing (..)
 import Json.Encode
 
 
@@ -10,8 +9,8 @@ encodeComment x =
     Json.Encode.object
         [ ( "commentPostId", Json.Encode.int x.postId )
         , ( "commentText", Json.Encode.string x.text )
-        , ( "commentMainCategories", (Exts.Json.Encode.tuple2 Json.Encode.string Json.Encode.string) x.mainCategories )
+        , ( "commentMainCategories", (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.string) >> (\( x, y ) -> Json.Encode.list [ x, y ]) >> Json.Encode.list) x.mainCategories )
         , ( "commentPublished", Json.Encode.bool x.published )
         , ( "commentCreated", (Json.Encode.string << toString) x.created )
-        , ( "commentTags", (Exts.Json.Encode.dict Json.Encode.string Json.Encode.int) x.tags )
+        , ( "commentTags", (Dict.toList >> List.map (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond (Json.Encode.int) >> (\( x, y ) -> Json.Encode.list [ x, y ])) >> Json.Encode.list) x.tags )
         ]

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -228,8 +228,6 @@ toElmDecoderSpec =
            [ "module CommentDecoder exposing (..)"
            , ""
            , "import CommentType exposing (..)"
-           , "import Dict"
-           , "import Exts.Json.Decode exposing (..)"
            , "import Json.Decode exposing (..)"
            , "import Json.Decode.Pipeline exposing (..)"
            , ""
@@ -323,7 +321,6 @@ toElmDecoderSpec =
            , ""
            , "import CommentType exposing (..)"
            , "import Dict"
-           , "import Exts.Json.Decode exposing (..)"
            , "import Json.Decode exposing (..)"
            , "import Json.Decode.Pipeline exposing (..)"
            , ""
@@ -414,7 +411,6 @@ toElmEncoderSpec =
            [ "module CommentEncoder exposing (..)"
            , ""
            , "import CommentType exposing (..)"
-           , "import Exts.Json.Encode exposing (..)"
            , "import Json.Encode"
            , ""
            , ""
@@ -444,7 +440,6 @@ toElmEncoderSpec =
            [ "module CommentEncoderWithOptions exposing (..)"
            , ""
            , "import CommentType exposing (..)"
-           , "import Exts.Json.Encode exposing (..)"
            , "import Json.Encode"
            , ""
            , ""
@@ -574,10 +569,10 @@ toElmEncoderSpec =
         "(Json.Encode.list << List.map (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
       it "toElmEncoderRef (Map String (Maybe String))" $
         toElmEncoderRef (Proxy :: Proxy (Map String (Maybe String))) `shouldBe`
-        "(Exts.Json.Encode.dict Json.Encode.string (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
+        "(Dict.toList >> List.map (Tuple.mapFirst (Json.Encode.string) >> Tuple.mapSecond ((Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string)) >> (\\( x, y ) -> Json.Encode.list [ x, y ])) >> Json.Encode.list)"
       it "toElmEncoderRef (IntMap (Maybe String))" $
         toElmEncoderRef (Proxy :: Proxy (IntMap (Maybe String))) `shouldBe`
-        "(Exts.Json.Encode.dict Json.Encode.int (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
+        "(Dict.toList >> List.map (Tuple.mapFirst (Json.Encode.int) >> Tuple.mapSecond ((Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string)) >> (\\( x, y ) -> Json.Encode.list [ x, y ])) >> Json.Encode.list)"
 
 moduleSpecsSpec :: Hspec.Spec
 moduleSpecsSpec =


### PR DESCRIPTION
This is not required to build working encoders, so it's nicer not to need to install it.