### PR TITLE
HasEncoder ElmValue needs to use the correct field name

### DIFF
--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -124,7 +124,7 @@ instance HasEncoder ElmValue where
     valueBody <- render value
     return . spaceparens $
       dquotes (stext (fieldModifier name)) <> comma <+>
-      (valueBody <+> "x." <> stext name)
+      (valueBody <+> "x." <> stext (fieldModifier name))
   render (ElmPrimitiveRef primitive) = renderRef 0 primitive
   render (ElmRef name) = pure $ "encode" <> stext name
   render (Values x y) = do

--- a/test/CommentEncoderWithOptions.elm
+++ b/test/CommentEncoderWithOptions.elm
@@ -8,10 +8,10 @@ import Json.Encode
 encodeComment : Comment -> Json.Encode.Value
 encodeComment x =
     Json.Encode.object
-        [ ( "commentPostId", Json.Encode.int x.postId )
-        , ( "commentText", Json.Encode.string x.text )
-        , ( "commentMainCategories", (\(m0, n0) -> Json.Encode.list identity [ Json.Encode.string m0, Json.Encode.string n0 ]) x.mainCategories )
-        , ( "commentPublished", Json.Encode.bool x.published )
-        , ( "commentCreated", (Iso8601.encode) x.created )
-        , ( "commentTags", (Json.Encode.dict Json.Encode.string Json.Encode.int) x.tags )
+        [ ( "commentPostId", Json.Encode.int x.commentPostId )
+        , ( "commentText", Json.Encode.string x.commentText )
+        , ( "commentMainCategories", (\(m0, n0) -> Json.Encode.list identity [ Json.Encode.string m0, Json.Encode.string n0 ]) x.commentMainCategories )
+        , ( "commentPublished", Json.Encode.bool x.commentPublished )
+        , ( "commentCreated", (Iso8601.encode) x.commentCreated )
+        , ( "commentTags", (Json.Encode.dict Json.Encode.string Json.Encode.int) x.commentTags )
         ]

--- a/test/PostEncoderWithOptions.elm
+++ b/test/PostEncoderWithOptions.elm
@@ -8,10 +8,10 @@ import PostType exposing (..)
 encodePost : Post -> Json.Encode.Value
 encodePost x =
     Json.Encode.object
-        [ ( "postId", Json.Encode.int x.id )
-        , ( "postName", Json.Encode.string x.name )
-        , ( "postAge", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.float) x.age )
-        , ( "postComments", (Json.Encode.list encodeComment) x.comments )
-        , ( "postPromoted", (Maybe.withDefault Json.Encode.null << Maybe.map encodeComment) x.promoted )
-        , ( "postAuthor", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string) x.author )
+        [ ( "postId", Json.Encode.int x.postId )
+        , ( "postName", Json.Encode.string x.postName )
+        , ( "postAge", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.float) x.postAge )
+        , ( "postComments", (Json.Encode.list encodeComment) x.postComments )
+        , ( "postPromoted", (Maybe.withDefault Json.Encode.null << Maybe.map encodeComment) x.postPromoted )
+        , ( "postAuthor", (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string) x.postAuthor )
         ]


### PR DESCRIPTION
This implements the fix proposed (over 5 years ago!!!) [on this issue](https://github.com/krisajenkins/elm-export/issues/40).  

You can see where this bit me in the following generated code: 

https://github.com/NoRedInk/NoRedInk/blob/d0d2c1f9038a0e8a3945f0703adb26328f8a53ec/lib/scaffolding/elm/generated/Generated/Backend/Scaffolding.elm#L120-L129