### PR TITLE
Support handling of `Data.Aeson.Value`

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ dependencies:
 - containers
 - text
 - time
+- aeson
 ghc-options:
 - -Wall
 

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -144,6 +144,7 @@ instance HasDecoderRef ElmPrimitive where
   renderRef EChar = pure "char"
   renderRef EFloat = pure "float"
   renderRef EString = pure "string"
+  renderRef EJsonValue = pure "value"
 
 toElmDecoderRefWith
   :: ElmType a

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -141,6 +141,7 @@ instance HasEncoderRef ElmPrimitive where
   renderRef _ EBool = pure "Json.Encode.bool"
   renderRef _ EFloat = pure "Json.Encode.float"
   renderRef _ EString = pure "Json.Encode.string"
+  renderRef _ EJsonValue = pure "identity"
   renderRef _ (EList (ElmPrimitive EChar)) = pure "Json.Encode.string"
   renderRef level (EList datatype) = do
     dd <- renderRef level datatype

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -95,6 +95,9 @@ instance HasTypeRef ElmPrimitive where
   renderRef EString = pure "String"
   renderRef EUnit = pure "()"
   renderRef EFloat = pure "Float"
+  renderRef EJsonValue = do
+    require "Json.Decode"
+    pure "Json.Decode.Value"
 
 -- | Puts parentheses around the doc of an elm ref if it contains spaces.
 elmRefParens :: ElmPrimitive -> Doc -> Doc

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -8,6 +8,7 @@
 
 module Elm.Type where
 
+import qualified Data.Aeson as Aeson
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.IntMap
 import Data.Map
@@ -32,6 +33,7 @@ data ElmPrimitive
   | EFloat
   | EString
   | EUnit
+  | EJsonValue
   | EList ElmDatatype
   | EMaybe ElmDatatype
   | ETuple2 ElmDatatype
@@ -162,6 +164,9 @@ instance ElmType Int32 where
 
 instance ElmType Int64 where
   toElmType _ = ElmPrimitive EInt
+
+instance ElmType Aeson.Value where
+  toElmType _ = ElmPrimitive EJsonValue
 
 instance (ElmType a, ElmType b) =>
          ElmType (a, b) where

--- a/test/AesonValueDecoder.elm
+++ b/test/AesonValueDecoder.elm
@@ -1,0 +1,11 @@
+module AesonValueDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import AesonValueType exposing (..)
+
+
+decodeAesonValue : Decoder AesonValue
+decodeAesonValue =
+    succeed AesonValue
+        |> required "aesonValue" value

--- a/test/AesonValueEncoder.elm
+++ b/test/AesonValueEncoder.elm
@@ -1,0 +1,11 @@
+module AesonValueEncoder exposing (..)
+
+import Json.Encode
+import AesonValueType exposing (..)
+
+
+encodeAesonValue : AesonValue -> Json.Encode.Value
+encodeAesonValue x =
+    Json.Encode.object
+        [ ( "aesonValue", identity x.aesonValue )
+        ]

--- a/test/AesonValueType.elm
+++ b/test/AesonValueType.elm
@@ -1,0 +1,8 @@
+module AesonValueType exposing (..)
+
+import Json.Decode
+
+
+type alias AesonValue =
+    { aesonValue : Json.Decode.Value
+    }

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -4,6 +4,7 @@
 
 module ExportSpec where
 
+import qualified Data.Aeson as Aeson
 import qualified Data.Algorithm.Diff as Diff
 import qualified Data.Algorithm.DiffOutput as DiffOutput
 import Data.Char
@@ -87,6 +88,11 @@ data LotsOfInts = LotsOfInts
 data Shadowing = Shadowing
   { prop :: ( (Int, Int), ( String, String ) )
   } deriving (Generic, ElmType)
+
+data AesonValue = AesonValue 
+  { aesonValue :: Aeson.Value 
+  } deriving (Generic, ElmType)
+
 
 
 spec :: Hspec.Spec
@@ -214,6 +220,19 @@ toElmTypeSpec =
         defaultOptions
         (Proxy :: Proxy Shadowing)
         "test/ShadowingType.elm"
+    it "toElmTypeSource AesonValue" $
+      shouldMatchTypeSource
+        (unlines
+          ["module AesonValueType exposing (..)"
+          , ""
+          , "import Json.Decode"
+          , ""
+          , ""
+          , "%s"
+          ])
+        defaultOptions
+        (Proxy :: Proxy AesonValue)
+        "test/AesonValueType.elm"
     describe "Convert to Elm type references." $ do
       it "toElmTypeRef Post" $
         toElmTypeRef (Proxy :: Proxy Post) `shouldBe` "Post"
@@ -410,6 +429,21 @@ toElmDecoderSpec =
         defaultOptions
         (Proxy :: Proxy Shadowing)
         "test/ShadowingDecoder.elm"
+    it "toElmDecoderSource AesonValue" $
+      shouldMatchDecoderSource
+        (unlines
+            [ "module AesonValueDecoder exposing (..)"
+            , ""
+            , "import Json.Decode exposing (..)"
+            , "import Json.Decode.Pipeline exposing (..)"
+            , "import AesonValueType exposing (..)"
+            , ""
+            , ""
+            , "%s"
+            ])
+        defaultOptions
+        (Proxy :: Proxy AesonValue)
+        "test/AesonValueDecoder.elm"
     describe "Convert to Elm decoder references." $ do
       it "toElmDecoderRef Post" $
         toElmDecoderRef (Proxy :: Proxy Post) `shouldBe` "decodePost"
@@ -598,6 +632,20 @@ toElmEncoderSpec =
         defaultOptions
         (Proxy :: Proxy Wrapper)
         "test/WrapperEncoder.elm"
+    it "toElmEncoderSourceWithOptions AesonValue" $
+      shouldMatchEncoderSource
+        (unlines
+           [ "module AesonValueEncoder exposing (..)"
+           , ""
+           , "import Json.Encode"
+           , "import AesonValueType exposing (..)"
+           , ""
+           , ""
+           , "%s"
+           ])
+        defaultOptions
+        (Proxy :: Proxy AesonValue)
+        "test/AesonValueEncoder.elm"
     describe "Convert to Elm encoder references." $ do
       it "toElmEncoderRef Post" $
         toElmEncoderRef (Proxy :: Proxy Post) `shouldBe` "encodePost"


### PR DESCRIPTION
This PR adds handling of `Data.Aeson.Value` to our elm-export fork.  `Data.Aeson.Value` in Haskell will be mapped to `Json.Decode.Value` in Elm and vice versa.

### Motivation

For scaffolding work I want to write a type that looks something like this: 

```hs
data VersionedSerialization = VersionedSerialization
  { version :: Int
  , serialization :: Data.Aeson.Value
  }
  deriving (Eq, Show, Generic)
  
 instance FromJSON VersionedSerialization
 instance ToJSON VersionedSerialization
 instance ElmType VersionedSerialization
```

This is so that I can write versioned decoders on the front end which will allow us to do safe migrations.  This structure will allow me to have the front end support V1 and V2 **before** writing any V2 data to the backend.

### Couldn't we just use `Text` instead of `Data.Aeson.Value`? 

Yes, but I think this is far more elegant! Having the type as `Data.Aeson.Value` better communicates intent.  This will be mapped to a `Json.Decode.Value` on the Elm side which makes it **very** clear what we're supposed to do with it (call `decodeValue`). 

I also plan on having `VersionedSerialization` stored in a single database column as a `jsonb` type. Compare what the serializations of `VersionedSerialization` look like with `Data.Aeson.Value` vs `Text`: 

```js
{ version = 1
, serialization = { x: 7, y: 8 }
```

```js
{ version = 1
, serialization = "{\"x\": 7, \"y\": 8}"
}
```

Directly encoding the `Data.Aeson.Value` is much cleaner! It would also allow us to use Postgres's cool JSON querying functions - which could be useful for inspecting the database. 