### PR TITLE
Nonempty support

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ library:
   - servant
   - wl-pprint-text
   - generic-lens
+  - semigroups
 
 tests:
   elm-export-test:

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -140,6 +140,9 @@ instance HasDecoderRef ElmPrimitive where
   renderRef (EList datatype) = do
     dt <- renderRef datatype
     return . parens $ "list" <+> dt
+  renderRef (ENonEmpty datatype) = do
+    dt <- renderRef datatype
+    return . parens $ "List.Nonempty.Extra.encoder" <+> dt
   renderRef (EDict EString value) = do
     require "Dict"
     d <- renderRef value

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -146,6 +146,9 @@ instance HasEncoderRef ElmPrimitive where
   renderRef level (EList datatype) = do
     dd <- renderRef level datatype
     return . parens $ "Json.Encode.list" <+> dd
+  renderRef level (ENonEmpty datatype) = do
+    dd <- renderRef level datatype
+    return . parens $ "List.Nonempty.Extra.encoder" <+> dd
   renderRef level (EMaybe datatype) = do
     dd <- renderRef level datatype
     return . parens $ "Maybe.withDefault Json.Encode.null << Maybe.map" <+> dd

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -80,6 +80,9 @@ instance HasTypeRef ElmPrimitive where
   renderRef (EList datatype) = do
     dt <- renderRef datatype
     return $ "List" <+> parens dt
+  renderRef (ENonEmpty datatype) = do
+    dt <- renderRef datatype
+    return $ parens ("Nonempty" <+> parens dt)
   renderRef (ETuple2 x y) = do
     dx <- renderRef x
     dy <- renderRef y

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -12,6 +12,7 @@ module Elm.Type where
 import qualified Data.Aeson as Aeson
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.IntMap
+import Data.List.NonEmpty (NonEmpty)
 import Data.Map
 import Data.Proxy
 import Data.Set (Set)
@@ -44,6 +45,7 @@ data ElmPrimitive
   | EUnit
   | EJsonValue
   | EList ElmDatatype
+  | ENonEmpty ElmDatatype
   | EMaybe ElmDatatype
   | ETuple2
       ElmDatatype
@@ -170,6 +172,12 @@ instance
   ElmType [a]
   where
   toElmType _ = ElmPrimitive (EList (toElmType (Proxy :: Proxy a)))
+
+instance
+  (ElmType a) =>
+  ElmType (NonEmpty a)
+  where
+  toElmType _ = ElmPrimitive (ENonEmpty (toElmType (Proxy :: Proxy a)))
 
 instance
   (ElmType a) =>

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -11,6 +11,7 @@ module ExportSpec where
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.Algorithm.Diff as Diff
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Algorithm.DiffOutput as DiffOutput
 import Data.Char
 import Data.Int
@@ -99,6 +100,7 @@ data Monstrosity
   | Dicts (Map Int64 ()) (Map Float Float)
   | SortDicts (Map Id Text) (Map School ()) (Map Color ()) (Map AnotherId Text)
   | SortSet (Set School) (Set AnotherId)
+  | NonEmptyList (NonEmpty String)
   deriving (Generic, ElmType)
 
 newtype Useless

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -205,7 +205,7 @@ toElmTypeSpec =
         "test/TimingType.elm"
     it "toElmTypeSource Monstrosity" $
       shouldMatchTypeSource
-        (unlines ["module MonstrosityType exposing (..)", "", "", "%s"])
+        (unlines ["module MonstrosityType exposing (..)", "", "import List.Nonempty exposing (Nonempty)", "", "", "%s"])
         defaultOptions
         (Proxy :: Proxy Monstrosity)
         "test/MonstrosityType.elm"
@@ -413,6 +413,7 @@ toElmDecoderSpec =
               "",
               "import Json.Decode exposing (..)",
               "import Json.Decode.Pipeline exposing (..)",
+              "import List.Nonempty.Extra",
               "import MonstrosityType exposing (..)",
               "",
               "",
@@ -665,6 +666,7 @@ toElmEncoderSpec =
             [ "module MonstrosityEncoder exposing (..)",
               "",
               "import Json.Encode",
+              "import List.Nonempty.Extra",
               "import MonstrosityType exposing (..)",
               "",
               "",

--- a/test/MonstrosityDecoder.elm
+++ b/test/MonstrosityDecoder.elm
@@ -2,6 +2,7 @@ module MonstrosityDecoder exposing (..)
 
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
+import List.Nonempty.Extra
 import MonstrosityType exposing (..)
 
 

--- a/test/MonstrosityDecoder.elm
+++ b/test/MonstrosityDecoder.elm
@@ -73,6 +73,10 @@ decodeMonstrosity =
                                                              map (Sorter.Set.fromList sorter) (list decodeSchool)))
                             |> required "contents" (index 1 (map Set.fromList (list int)))
 
+                    "NonEmptyList" ->
+                        succeed NonEmptyList
+                            |> required "contents" (List.Nonempty.Extra.encoder string)
+
                     _ ->
                         fail "Constructor not matched"
             )

--- a/test/MonstrosityEncoder.elm
+++ b/test/MonstrosityEncoder.elm
@@ -1,6 +1,7 @@
 module MonstrosityEncoder exposing (..)
 
 import Json.Encode
+import List.Nonempty.Extra
 import MonstrosityType exposing (..)
 
 

--- a/test/MonstrosityEncoder.elm
+++ b/test/MonstrosityEncoder.elm
@@ -52,3 +52,9 @@ encodeMonstrosity x =
                 [ ( "tag", Json.Encode.string "SortSet" )
                 , ( "contents", Json.Encode.list identity [ (Sort.Set.toList >> Json.Encode.list encodeSchool) y0, (Json.Encode.set Json.Encode.int) y1 ] )
                 ]
+
+        NonEmptyList y0 ->
+            Json.Encode.object
+                [ ( "tag", Json.Encode.string "NonEmptyList" )
+                , ( "contents", (List.Nonempty.Extra.encoder Json.Encode.string) y0 )
+                ]

--- a/test/MonstrosityType.elm
+++ b/test/MonstrosityType.elm
@@ -8,3 +8,4 @@ type Monstrosity
     | Dicts (Dict (Int) (())) (Dict (Float) (Float))
     | SortDicts (Sort.Dict.Dict (Id) (String)) (Sort.Dict.Dict (School) (())) (Sort.Dict.Dict (Color) (())) (Dict (Int) (String))
     | SortSet (Sort.Set.Set (School)) (Set (Int))
+    | NonEmptyList (Nonempty (String))

--- a/test/MonstrosityType.elm
+++ b/test/MonstrosityType.elm
@@ -1,5 +1,7 @@
 module MonstrosityType exposing (..)
 
+import List.Nonempty exposing (Nonempty)
+
 
 type Monstrosity
     = NotSpecial


### PR DESCRIPTION
We went through the trouble of encoding `NonEmpty` in some types in CCS.

Would be nice to not lose that guarantee in the front-end.