### PR TITLE
Support non standard encoder/decoder names

### DIFF
--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -38,7 +38,7 @@ instance HasDecoder ElmDatatype where
 instance HasDecoderRef ElmDatatype where
   renderRef (ElmDatatype name _) = pure $ "decode" <> stext name
   renderRef (ElmPrimitive primitive) = renderRef primitive
-  renderRef (CreatedInElm (FromElm _ decoderName _)) = pure $ stext decoderName
+  renderRef (CreatedInElm elmRefData) = pure $ stext (decoderFunction elmRefData)
 
 instance HasDecoder ElmConstructor where
   render (NamedConstructor name ElmEmpty) =
@@ -125,7 +125,7 @@ renderConstructorArgs i val = do
   pure (i, "|>" <+> requiredContents <+> index)
 
 instance HasDecoder ElmValue where
-  render (ElmRef elmRefData) = pure $ stext (elmRefDecoder elmRefData)
+  render (ElmRef elmRefData) = pure $ stext (decoderFunction elmRefData)
   render (ElmPrimitiveRef primitive) = renderRef primitive
   render (Values x y) = do
     dx <- render x

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -125,7 +125,7 @@ renderConstructorArgs i val = do
   pure (i, "|>" <+> requiredContents <+> index)
 
 instance HasDecoder ElmValue where
-  render (ElmRef name) = pure $ "decode" <> stext name
+  render (ElmRef elmRefData) = pure $ stext (elmRefDecoder elmRefData)
   render (ElmPrimitiveRef primitive) = renderRef primitive
   render (Values x y) = do
     dx <- render x

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -33,10 +33,12 @@ instance HasDecoder ElmDatatype where
       (fnName <+> ": Decoder" <+> stext name)
         <$$> (fnName <+> "=" <$$> indent 4 ctor)
   render (ElmPrimitive primitive) = renderRef primitive
+  render (CreatedInElm _) = pure $ stext ""
 
 instance HasDecoderRef ElmDatatype where
   renderRef (ElmDatatype name _) = pure $ "decode" <> stext name
   renderRef (ElmPrimitive primitive) = renderRef primitive
+  renderRef (CreatedInElm (FromElm _ decoderName _)) = pure $ stext decoderName
 
 instance HasDecoder ElmConstructor where
   render (NamedConstructor name ElmEmpty) =

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -34,7 +34,7 @@ instance HasEncoder ElmDatatype where
 instance HasEncoderRef ElmDatatype where
   renderRef _ (ElmDatatype name _) = pure $ "encode" <> stext name
   renderRef level (ElmPrimitive primitive) = renderRef level primitive
-  renderRef _ (CreatedInElm (FromElm _ _ encoderName)) = pure $ stext encoderName
+  renderRef _ (CreatedInElm elmRefData) = pure $ stext (encoderFunction elmRefData)
 
 instance HasEncoder ElmConstructor where
   -- Single constructor, no values: empty array
@@ -128,7 +128,7 @@ instance HasEncoder ElmValue where
         <> comma
         <+> (valueBody <+> "x." <> stext (fieldModifier name))
   render (ElmPrimitiveRef primitive) = renderRef 0 primitive
-  render (ElmRef elmRefData) = pure $ stext (elmRefEncoder elmRefData)
+  render (ElmRef elmRefData) = pure $ stext (encoderFunction elmRefData)
   render (Values x y) = do
     dx <- render x
     dy <- render y

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -128,7 +128,7 @@ instance HasEncoder ElmValue where
         <> comma
         <+> (valueBody <+> "x." <> stext (fieldModifier name))
   render (ElmPrimitiveRef primitive) = renderRef 0 primitive
-  render (ElmRef name) = pure $ "encode" <> stext name
+  render (ElmRef elmRefData) = pure $ stext (elmRefEncoder elmRefData)
   render (Values x y) = do
     dx <- render x
     dy <- render y

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -29,10 +29,12 @@ instance HasEncoder ElmDatatype where
       (fnName <+> ":" <+> stext name <+> "->" <+> "Json.Encode.Value")
         <$$> (fnName <+> "x =" <$$> indent 4 ctor)
   render (ElmPrimitive primitive) = renderRef 0 primitive
+  render (CreatedInElm _) = pure $ stext ""
 
 instance HasEncoderRef ElmDatatype where
   renderRef _ (ElmDatatype name _) = pure $ "encode" <> stext name
   renderRef level (ElmPrimitive primitive) = renderRef level primitive
+  renderRef _ (CreatedInElm (FromElm _ _ encoderName)) = pure $ stext encoderName
 
 instance HasEncoder ElmConstructor where
   -- Single constructor, no values: empty array

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -57,7 +57,7 @@ instance HasType ElmConstructor where
     mintercalate (line <> "|" <> space) <$> sequence (render <$> constructors)
 
 instance HasType ElmValue where
-  render (ElmRef name) = pure (stext name)
+  render (ElmRef elmRefData) = pure (stext (elmRefName elmRefData))
   render (ElmPrimitiveRef primitive) = elmRefParens primitive <$> renderRef primitive
   render ElmEmpty = pure (text "")
   render (Values x y) = do

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -39,10 +39,12 @@ instance HasType ElmDatatype where
     ctor <- render constructor
     return . nest 4 $ "type" <+> name <$$> "=" <+> ctor
   render (ElmPrimitive primitive) = renderRef primitive
+  render (CreatedInElm _) = pure $ stext ""
 
 instance HasTypeRef ElmDatatype where
   renderRef (ElmDatatype typeName _) = pure (stext typeName)
   renderRef (ElmPrimitive primitive) = renderRef primitive
+  renderRef (CreatedInElm (FromElm typeName _ _)) = pure (stext typeName)
 
 instance HasType ElmConstructor where
   render (RecordConstructor _ value) = do

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -44,7 +44,7 @@ instance HasType ElmDatatype where
 instance HasTypeRef ElmDatatype where
   renderRef (ElmDatatype typeName _) = pure (stext typeName)
   renderRef (ElmPrimitive primitive) = renderRef primitive
-  renderRef (CreatedInElm (FromElm typeName _ _)) = pure (stext typeName)
+  renderRef (CreatedInElm elmRefData) = pure (stext (typeName elmRefData))
 
 instance HasType ElmConstructor where
   render (RecordConstructor _ value) = do
@@ -57,7 +57,7 @@ instance HasType ElmConstructor where
     mintercalate (line <> "|" <> space) <$> sequence (render <$> constructors)
 
 instance HasType ElmValue where
-  render (ElmRef elmRefData) = pure (stext (elmRefName elmRefData))
+  render (ElmRef elmRefData) = pure (stext (typeName elmRefData))
   render (ElmPrimitiveRef primitive) = elmRefParens primitive <$> renderRef primitive
   render ElmEmpty = pure (text "")
   render (Values x y) = do

--- a/src/Elm/Type.hs
+++ b/src/Elm/Type.hs
@@ -22,11 +22,19 @@ import GHC.Generics
 import Servant.API (Headers (getResponse))
 import Prelude
 
+data FromElm = FromElm
+  { typeName :: Text,
+    decoderName :: Text,
+    encoderName :: Text
+  }
+  deriving (Show, Eq)
+
 data ElmDatatype
   = ElmDatatype
       Text
       ElmConstructor
   | ElmPrimitive ElmPrimitive
+  | CreatedInElm FromElm
   deriving (Show, Eq)
 
 data MapEncoding
@@ -92,6 +100,9 @@ class ElmType a where
     (Generic a, GenericElmDatatype (Rep a)) =>
     a ->
     ElmDatatype
+
+fromElm :: FromElm -> a -> ElmDatatype
+fromElm x _ = CreatedInElm x
 
 ------------------------------------------------------------
 class GenericElmDatatype f where
@@ -164,6 +175,7 @@ instance
     case toElmType (Proxy :: Proxy a) of
       ElmPrimitive primitive -> ElmPrimitiveRef primitive
       ElmDatatype name _ -> ElmRef name
+      CreatedInElm fromElm -> ElmRef (typeName fromElm)
 
 instance
   (ElmType a) =>

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -135,6 +135,16 @@ data AesonValue = AesonValue
   }
   deriving (Generic, ElmType)
 
+data TFromElm = A | B | C | D
+
+instance ElmType TFromElm where
+  toElmType = fromElm (FromElm {typeName = "FromElm", decoderName = "decodeFromElm", encoderName = "encodeFromElm"})
+
+data FieldWithFromElm = FieldWithFromElm
+  { fieldWithFromElm :: TFromElm
+  }
+  deriving (Generic, ElmType)
+
 spec :: Hspec.Spec
 spec = do
   toElmTypeSpec
@@ -295,6 +305,18 @@ toElmTypeSpec =
         defaultOptions
         (Proxy :: Proxy AesonValue)
         "test/AesonValueType.elm"
+    it "toElmTypeSource FieldWithFromElm" $
+      shouldMatchTypeSource
+        ( unlines
+            [ "module FieldWithFromElmType exposing (..)",
+              "",
+              "",
+              "%s"
+            ]
+        )
+        defaultOptions
+        (Proxy :: Proxy FieldWithFromElm)
+        "test/FieldWithFromElmType.elm"
     describe "Convert to Elm type references." $ do
       it "toElmTypeRef Post" $
         toElmTypeRef (Proxy :: Proxy Post) `shouldBe` "Post"
@@ -316,6 +338,8 @@ toElmTypeSpec =
       it "toElmTypeRef (IntMap (Maybe String))" $
         toElmTypeRef (Proxy :: Proxy (IntMap (Maybe String)))
           `shouldBe` "Dict (Int) (Maybe (String))"
+      it "toElmTypeRef TFromElm" $
+        toElmTypeRef (Proxy :: Proxy TFromElm) `shouldBe` "FromElm"
 
 toElmDecoderSpec :: Hspec.Spec
 toElmDecoderSpec =
@@ -518,6 +542,22 @@ toElmDecoderSpec =
         defaultOptions
         (Proxy :: Proxy AesonValue)
         "test/AesonValueDecoder.elm"
+    it "toElmDecoderSource FieldWithFromElm" $
+      shouldMatchDecoderSource
+        ( unlines
+            [ "module FieldWithFromElmDecoder exposing (..)",
+              "",
+              "import Json.Decode exposing (..)",
+              "import Json.Decode.Pipeline exposing (..)",
+              "import FieldWithFromElmType exposing (..)",
+              "",
+              "",
+              "%s"
+            ]
+        )
+        defaultOptions
+        (Proxy :: Proxy FieldWithFromElm)
+        "test/FieldWithFromElmDecoder.elm"
     describe "Convert to Elm decoder references." $ do
       it "toElmDecoderRef Post" $
         toElmDecoderRef (Proxy :: Proxy Post) `shouldBe` "decodePost"
@@ -544,6 +584,8 @@ toElmDecoderSpec =
       it "toElmDecoderRef (IntMap (Maybe String))" $
         toElmDecoderRef (Proxy :: Proxy (IntMap (Maybe String)))
           `shouldBe` "(Json.Decode.Extra.dict2 int (nullable string))"
+      it "toElmDecoderRef TFromElm" $
+        toElmDecoderRef (Proxy :: Proxy TFromElm) `shouldBe` "decodeFromElm"
 
 toElmEncoderSpec :: Hspec.Spec
 toElmEncoderSpec =
@@ -732,6 +774,21 @@ toElmEncoderSpec =
         defaultOptions
         (Proxy :: Proxy AesonValue)
         "test/AesonValueEncoder.elm"
+    it "toElmEncoderSourceWithOptions FieldWithFromElm" $
+      shouldMatchEncoderSource
+        ( unlines
+            [ "module FieldWithFromElmEncoder exposing (..)",
+              "",
+              "import Json.Encode",
+              "import FieldWithFromElmType exposing (..)",
+              "",
+              "",
+              "%s"
+            ]
+        )
+        defaultOptions
+        (Proxy :: Proxy FieldWithFromElm)
+        "test/FieldWithFromElmEncoder.elm"
     describe "Convert to Elm encoder references." $ do
       it "toElmEncoderRef Post" $
         toElmEncoderRef (Proxy :: Proxy Post) `shouldBe` "encodePost"
@@ -758,6 +815,8 @@ toElmEncoderSpec =
       it "toElmEncoderRef (IntMap (Maybe String))" $
         toElmEncoderRef (Proxy :: Proxy (IntMap (Maybe String)))
           `shouldBe` "(Json.Encode.dict String.fromInt (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
+      it "toElmEncoderRef TFromElm" $
+        toElmEncoderRef (Proxy :: Proxy TFromElm) `shouldBe` "encodeFromElm"
 
 moduleSpecsSpec :: Hspec.Spec
 moduleSpecsSpec =

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -138,7 +138,7 @@ data AesonValue = AesonValue
 data TFromElm = A | B | C | D
 
 instance ElmType TFromElm where
-  toElmType = fromElm (FromElm {typeName = "FromElm", decoderName = "existingDecodeFromElm", encoderName = "existingEncodeFromElm"})
+  toElmType = fromElm (ElmRefData {typeName = "FromElm", decoderFunction = "existingDecodeFromElm", encoderFunction = "existingEncodeFromElm"})
 
 data FieldWithFromElm = FieldWithFromElm
   { fieldWithFromElm :: TFromElm

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -138,7 +138,7 @@ data AesonValue = AesonValue
 data TFromElm = A | B | C | D
 
 instance ElmType TFromElm where
-  toElmType = fromElm (FromElm {typeName = "FromElm", decoderName = "decodeFromElm", encoderName = "encodeFromElm"})
+  toElmType = fromElm (FromElm {typeName = "FromElm", decoderName = "existingDecodeFromElm", encoderName = "existingEncodeFromElm"})
 
 data FieldWithFromElm = FieldWithFromElm
   { fieldWithFromElm :: TFromElm
@@ -585,7 +585,7 @@ toElmDecoderSpec =
         toElmDecoderRef (Proxy :: Proxy (IntMap (Maybe String)))
           `shouldBe` "(Json.Decode.Extra.dict2 int (nullable string))"
       it "toElmDecoderRef TFromElm" $
-        toElmDecoderRef (Proxy :: Proxy TFromElm) `shouldBe` "decodeFromElm"
+        toElmDecoderRef (Proxy :: Proxy TFromElm) `shouldBe` "existingDecodeFromElm"
 
 toElmEncoderSpec :: Hspec.Spec
 toElmEncoderSpec =
@@ -816,7 +816,7 @@ toElmEncoderSpec =
         toElmEncoderRef (Proxy :: Proxy (IntMap (Maybe String)))
           `shouldBe` "(Json.Encode.dict String.fromInt (Maybe.withDefault Json.Encode.null << Maybe.map Json.Encode.string))"
       it "toElmEncoderRef TFromElm" $
-        toElmEncoderRef (Proxy :: Proxy TFromElm) `shouldBe` "encodeFromElm"
+        toElmEncoderRef (Proxy :: Proxy TFromElm) `shouldBe` "existingEncodeFromElm"
 
 moduleSpecsSpec :: Hspec.Spec
 moduleSpecsSpec =

--- a/test/FieldWithFromElmDecoder.elm
+++ b/test/FieldWithFromElmDecoder.elm
@@ -8,4 +8,4 @@ import FieldWithFromElmType exposing (..)
 decodeFieldWithFromElm : Decoder FieldWithFromElm
 decodeFieldWithFromElm =
     succeed FieldWithFromElm
-        |> required "fieldWithFromElm" decodeFromElm
+        |> required "fieldWithFromElm" existingDecodeFromElm

--- a/test/FieldWithFromElmDecoder.elm
+++ b/test/FieldWithFromElmDecoder.elm
@@ -1,0 +1,11 @@
+module FieldWithFromElmDecoder exposing (..)
+
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+import FieldWithFromElmType exposing (..)
+
+
+decodeFieldWithFromElm : Decoder FieldWithFromElm
+decodeFieldWithFromElm =
+    succeed FieldWithFromElm
+        |> required "fieldWithFromElm" decodeFromElm

--- a/test/FieldWithFromElmEncoder.elm
+++ b/test/FieldWithFromElmEncoder.elm
@@ -1,0 +1,11 @@
+module FieldWithFromElmEncoder exposing (..)
+
+import Json.Encode
+import FieldWithFromElmType exposing (..)
+
+
+encodeFieldWithFromElm : FieldWithFromElm -> Json.Encode.Value
+encodeFieldWithFromElm x =
+    Json.Encode.object
+        [ ( "fieldWithFromElm", encodeFromElm x.fieldWithFromElm )
+        ]

--- a/test/FieldWithFromElmEncoder.elm
+++ b/test/FieldWithFromElmEncoder.elm
@@ -7,5 +7,5 @@ import FieldWithFromElmType exposing (..)
 encodeFieldWithFromElm : FieldWithFromElm -> Json.Encode.Value
 encodeFieldWithFromElm x =
     Json.Encode.object
-        [ ( "fieldWithFromElm", encodeFromElm x.fieldWithFromElm )
+        [ ( "fieldWithFromElm", existingEncodeFromElm x.fieldWithFromElm )
         ]

--- a/test/FieldWithFromElmType.elm
+++ b/test/FieldWithFromElmType.elm
@@ -1,0 +1,6 @@
+module FieldWithFromElmType exposing (..)
+
+
+type alias FieldWithFromElm =
+    { fieldWithFromElm : FromElm
+    }


### PR DESCRIPTION
@celsobonutti while trying to use #16 I noticed that if the existing encoder/decoder does not follow the encoder{Type} / decoder{Type} convention then the generated code that not work.

I was able to fix that but I am not convinced of the approach. There are some overlaps  with Encoder/Decoder modules that also defines the encoder{Type} / decoder{Type} function names for ElmDatatype. This was the case before the PR and why it was not handled by #16.

WDYT?