### PR TITLE
need this to easily sort Int32s from monorepo

### DIFF
--- a/src/Elm/Sorter.hs
+++ b/src/Elm/Sorter.hs
@@ -13,7 +13,7 @@
 module Elm.Sorter (Sorter, mkRecordSorter, mkCustom, HasElmSorter (..), render) where
 
 import Data.Generics.Product.Fields (HasField')
-import Data.Int (Int64)
+import Data.Int (Int32, Int64)
 import Data.Proxy
 import Data.Text (Text, pack)
 import Elm.Common (letIn)
@@ -126,6 +126,9 @@ elmSorterRecord _ =
   ByField (pack $ symbolVal (Proxy :: Proxy fieldName)) (elmSorter (Proxy :: Proxy interior))
 
 instance HasElmSorter Int where
+  elmSorter _ = Increasing
+
+instance HasElmSorter Int32 where
   elmSorter _ = Increasing
 
 instance HasElmSorter Int64 where


### PR DESCRIPTION
When, in the monorepo, I try

```haskell
newtype TopicId = TopicId Data.Int.Int32
  deriving
    ( Eq,
      Ord,
      Show,
      Generic,
      PGColumn "integer",
      PGParameter "integer",
      ToJSONKey,
      FromJSONKey,
      ElmType,
      HasElmSorter
    )
```

I get

```
Haskell               | src/Data/Topic/Id.hs:25:7-18: error:
Haskell               |     • No instance for (HasElmSorter Data.Int.Int32)
Haskell               |         arising from the 'deriving' clause of a data type declaration
Haskell               |       Possible fix:
Haskell               |         use a standalone 'deriving instance' declaration,
Haskell               |           so you can specify the instance context yourself
Haskell               |     • When deriving the instance for (HasElmSorter TopicId)
```

so I figure I can solve this right in my code with

```haskell
instance HasElmSorter Data.Int.Int32 where
  elmSorter _ = Elm.Increasing
```

but then my problem is

```
Haskell               | src/Data/Topic/Id.hs:29:17-30: error:
Haskell               |     Not in scope: data constructor ‘Elm.Increasing’
Haskell               |     Module ‘Elm’ does not export ‘Increasing’.
Haskell               |    |
Haskell               | 29 |   elmSorter _ = Elm.Increasing
```

so that's why I'm adding the sorter here. I do not know how to use my local copy of this repo with my monorepo and test this.