### PR TITLE
Support recursive records

### DIFF
--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -51,7 +51,7 @@ l <$+$> r = l <> emptyline <$$> r
 --
 type RenderM = RWS Options (Set Text -- The set of required imports
                             , [Text] -- Generated declarations
-                            ) ()
+                            ) Text
 
 {-| Add an import to the set.
 -}
@@ -63,7 +63,7 @@ declarations.
 -}
 collectDeclaration :: RenderM Doc -> RenderM ()
 collectDeclaration =
-  mapRWS ((\(defn, (), (imports, _)) -> ((), (), (imports, [pprinter defn]))))
+  mapRWS ((\(defn, s, (imports, _)) -> ((), s, (imports, [pprinter defn]))))
 
 squarebracks :: Doc -> Doc
 squarebracks doc = "[" <+> doc <+> "]"

--- a/src/Elm/Encoder.hs
+++ b/src/Elm/Encoder.hs
@@ -207,7 +207,7 @@ toElmEncoderRefWith ::
   a ->
   T.Text
 toElmEncoderRefWith options x =
-  pprinter . fst $ evalRWS (renderRef 0 (toElmType x)) options ()
+  pprinter . fst $ evalRWS (renderRef 0 (toElmType x)) options ""
 
 toElmEncoderRef ::
   (ElmType a) =>
@@ -221,7 +221,7 @@ toElmEncoderSourceWith ::
   a ->
   T.Text
 toElmEncoderSourceWith options x =
-  pprinter . fst $ evalRWS (render (toElmType x)) options ()
+  pprinter . fst $ evalRWS (render (toElmType x)) options ""
 
 toElmEncoderSource ::
   (ElmType a) =>

--- a/src/Elm/File.hs
+++ b/src/Elm/File.hs
@@ -53,7 +53,7 @@ specsToDir specs rootDir = mapM_ processSpec specs
 
 moduleSpecWith :: Options -> [Text] -> RenderM () -> Spec
 moduleSpecWith options ns m =
-  let ((), (imports, defns)) = execRWS m options ()
+  let (_, (imports, defns)) = execRWS m options ""
   in Spec
      { namespace = ns
      , declarations =

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -140,7 +140,7 @@ toElmTypeRefWith ::
   a ->
   T.Text
 toElmTypeRefWith options x =
-  pprinter . fst $ evalRWS (renderRef (toElmType x)) options ()
+  pprinter . fst $ evalRWS (renderRef (toElmType x)) options ""
 
 toElmTypeRef ::
   (ElmType a) =>
@@ -154,7 +154,7 @@ toElmTypeSourceWith ::
   a ->
   T.Text
 toElmTypeSourceWith options x =
-  pprinter . fst $ evalRWS (render (toElmType x)) options ()
+  pprinter . fst $ evalRWS (render (toElmType x)) options ""
 
 toElmSorterSource :: (ElmType a, HasElmSorter a) => Proxy a -> T.Text
 toElmSorterSource p =

--- a/src/Elm/Record.hs
+++ b/src/Elm/Record.hs
@@ -30,7 +30,7 @@ class HasTypeRef a where
   renderRef :: a -> RenderM Doc
 
 instance HasType ElmDatatype where
-  render d@(ElmDatatype _ constructor@(RecordConstructor _ _)) = do
+  render d@(ElmDatatype _ constructor@(RecordConstructor _ _ False)) = do
     name <- renderRef d
     ctor <- render constructor
     return . nest 4 $ "type alias" <+> name <+> "=" <$$> ctor
@@ -47,9 +47,12 @@ instance HasTypeRef ElmDatatype where
   renderRef (CreatedInElm elmRefData) = pure (stext (typeName elmRefData))
 
 instance HasType ElmConstructor where
-  render (RecordConstructor _ value) = do
+  render (RecordConstructor _ value False) = do
     dv <- renderRecord value
     return $ "{" <+> dv <$$> "}"
+  render (RecordConstructor name value True) = do
+    dv <- renderRecord value
+    return $ stext name <$$> indent 4 ("{" <+> dv <$$> "}")
   render (NamedConstructor constructorName value) = do
     dv <- render value
     return $ stext constructorName <+> dv

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
@@ -63,6 +64,12 @@ data Timing
   | Continue Double
   | Stop
   deriving (Generic, ElmType)
+
+data RecursiveRecord = RecursiveRecord {rec :: Maybe RecursiveRecord, otherField :: Text}
+  deriving (Generic)
+  deriving (ElmType) via TagRecord RecursiveRecord
+
+-- type RecursiveRecord = RecursiveRecord { rec : Maybe RecursiveRecord }
 
 newtype Id = Id Int
   deriving (Generic, ElmType, HasElmSorter, Aeson.ToJSON, Aeson.ToJSONKey)
@@ -250,6 +257,18 @@ toElmTypeSpec =
         defaultOptions
         (Proxy :: Proxy FavoritePlaces)
         "test/FavoritePlacesType.elm"
+    it "toElmTypeSource RecursiveRecord" $
+      shouldMatchTypeSource
+        ( unlines
+            [ "module RecursiveRecordType exposing (..)",
+              "",
+              "",
+              "%s"
+            ]
+        )
+        defaultOptions
+        (Proxy :: Proxy RecursiveRecord)
+        "test/RecursiveRecordType.elm"
     it "toElmTypeSourceWithOptions Post" $
       shouldMatchTypeSource
         ( unlines
@@ -379,6 +398,22 @@ toElmDecoderSpec =
         defaultOptions
         (Proxy :: Proxy Post)
         "test/PostDecoder.elm"
+    it "toElmDecoderSource RecursiveRecordDecoder" $
+      shouldMatchDecoderSource
+        ( unlines
+            [ "module RecursiveRecordDecoder exposing (..)",
+              "",
+              "import CommentDecoder exposing (..)",
+              "import Json.Decode exposing (..)",
+              "import Json.Decode.Pipeline exposing (..)",
+              "",
+              "",
+              "%s"
+            ]
+        )
+        defaultOptions
+        (Proxy :: Proxy RecursiveRecord)
+        "test/RecursiveRecordDecoder.elm"
     it "toElmDecoderSourceWithOptions Post" $
       shouldMatchDecoderSource
         ( unlines
@@ -622,6 +657,20 @@ toElmEncoderSpec =
         defaultOptions
         (Proxy :: Proxy Post)
         "test/PostEncoder.elm"
+    it "toElmEncoderSource RecursiveRecord" $
+      shouldMatchEncoderSource
+        ( unlines
+            [ "module RecursiveRecordEncoder exposing (..)",
+              "",
+              "import Json.Encode",
+              "",
+              "",
+              "%s"
+            ]
+        )
+        defaultOptions
+        (Proxy :: Proxy RecursiveRecord)
+        "test/RecursiveRecordEncoder.elm"
     it "toElmEncoderSourceWithOptions Comment" $
       shouldMatchEncoderSource
         ( unlines

--- a/test/MonstrosityDecoder.elm
+++ b/test/MonstrosityDecoder.elm
@@ -16,13 +16,13 @@ decodeMonstrosity =
 
                     "OkayIGuess" ->
                         succeed OkayIGuess
-                            |> required "contents" decodeMonstrosity
+                            |> required "contents" (lazy (\() -> decodeMonstrosity))
 
                     "Ridiculous" ->
                         succeed Ridiculous
                             |> required "contents" (index 0 int)
                             |> required "contents" (index 1 string)
-                            |> required "contents" (index 2 (list decodeMonstrosity))
+                            |> required "contents" (index 2 (list (lazy (\() -> decodeMonstrosity))))
                             |> required "contents" (index 3 (map Set.fromList (list float)))
 
                     "Dicts" ->

--- a/test/RecursiveRecordDecoder.elm
+++ b/test/RecursiveRecordDecoder.elm
@@ -8,5 +8,5 @@ import Json.Decode.Pipeline exposing (..)
 decodeRecursiveRecord : Decoder RecursiveRecord
 decodeRecursiveRecord =
     succeed (\rec otherField -> RecursiveRecord {rec = rec, otherField = otherField})
-        |> required "rec" (nullable decodeRecursiveRecord)
+        |> required "rec" (nullable (lazy (\() -> decodeRecursiveRecord)))
         |> required "otherField" string

--- a/test/RecursiveRecordDecoder.elm
+++ b/test/RecursiveRecordDecoder.elm
@@ -1,0 +1,12 @@
+module RecursiveRecordDecoder exposing (..)
+
+import CommentDecoder exposing (..)
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline exposing (..)
+
+
+decodeRecursiveRecord : Decoder RecursiveRecord
+decodeRecursiveRecord =
+    succeed (\rec otherField -> RecursiveRecord {rec = rec, otherField = otherField})
+        |> required "rec" (nullable decodeRecursiveRecord)
+        |> required "otherField" string

--- a/test/RecursiveRecordEncoder.elm
+++ b/test/RecursiveRecordEncoder.elm
@@ -1,0 +1,11 @@
+module RecursiveRecordEncoder exposing (..)
+
+import Json.Encode
+
+
+encodeRecursiveRecord : RecursiveRecord -> Json.Encode.Value
+encodeRecursiveRecord (RecursiveRecord x) =
+    Json.Encode.object
+        [ ( "rec", (Maybe.withDefault Json.Encode.null << Maybe.map encodeRecursiveRecord) x.rec )
+        , ( "otherField", Json.Encode.string x.otherField )
+        ]

--- a/test/RecursiveRecordType.elm
+++ b/test/RecursiveRecordType.elm
@@ -1,0 +1,8 @@
+module RecursiveRecordType exposing (..)
+
+
+type RecursiveRecord
+    = RecursiveRecord
+        { rec : Maybe (RecursiveRecord)
+        , otherField : String
+        }


### PR DESCRIPTION
Add support to generate tagged records (non-type alias ones) through the use of the `DerivingVia` extension.