### PR TITLE
Add fault-tolerant list decoding

### DIFF
--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -11,11 +11,19 @@ import Formatting hiding (text)
 import Text.PrettyPrint.Leijen.Text hiding ((<$>))
 
 data Options = Options
-  { fieldLabelModifier :: Text -> Text
+  { fieldLabelModifier :: Text -> Text,
+    -- | When True, decoders are tolerant of missing list fields and
+    -- | will default them to an empty list []. This is helpful in supporting
+    -- | third-party APIs that remove empty fields from the response.
+    optionalListFields :: Bool
   }
 
 defaultOptions :: Options
-defaultOptions = Options {fieldLabelModifier = id}
+defaultOptions =
+  Options
+    { fieldLabelModifier = id,
+      optionalListFields = False
+    }
 
 cr :: Format r r
 cr = now "\n"

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -160,13 +160,13 @@ instance HasDecoder ElmValue where
     return $ dx <$$> dy
   render (ElmField name value) = do
     fieldModifier <- asks fieldLabelModifier
-    optionalListFields <- asks optionalListFields
+    optionalListFields' <- asks optionalListFields
     dv <- render value
     let isList = case value of
           (ElmPrimitiveRef (EList value'))
             | value' /= (ElmPrimitive EChar) -> True
           _ -> False
-    if isList && optionalListFields
+    if isList && optionalListFields'
       then return $ "|> optional" <+> dquotes (stext (fieldModifier name)) <+> dv <+> "[]"
       else return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
   render ElmEmpty = pure (stext "")

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -160,8 +160,15 @@ instance HasDecoder ElmValue where
     return $ dx <$$> dy
   render (ElmField name value) = do
     fieldModifier <- asks fieldLabelModifier
+    optionalListFields <- asks optionalListFields
     dv <- render value
-    return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
+    let isList = case value of
+          (ElmPrimitiveRef (EList value'))
+            | value' /= (ElmPrimitive EChar) -> True
+          _ -> False
+    if isList && optionalListFields
+      then return $ "|> optional" <+> dquotes (stext (fieldModifier name)) <+> dv <+> "[]"
+      else return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
   render ElmEmpty = pure (stext "")
 
 instance HasDecoderRef ElmPrimitive where

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -428,7 +428,7 @@ toElmDecoderSpec =
               "%s"
             ]
         )
-        (defaultOptions {fieldLabelModifier = withPrefix "post"})
+        (defaultOptions {fieldLabelModifier = withPrefix "post", optionalListFields = True})
         (Proxy :: Proxy Post)
         "test/PostDecoderWithOptions.elm"
     it "toElmDecoderSource Position" $

--- a/test/PostDecoderWithOptions.elm
+++ b/test/PostDecoderWithOptions.elm
@@ -12,6 +12,6 @@ decodePost =
         |> required "postId" int
         |> required "postName" string
         |> required "postAge" (nullable float)
-        |> required "postComments" (list decodeComment)
+        |> optional "postComments" (list decodeComment) []
         |> required "postPromoted" (nullable decodeComment)
         |> required "postAuthor" (nullable string)


### PR DESCRIPTION
Adds an `optionalListFields` option that supports fault-tolerant decoding of apis that remove empty lists from responses.

Does not change encoding behavior.