### PR TITLE
Add optionalMaybeFields

### DIFF
--- a/src/Elm/Common.hs
+++ b/src/Elm/Common.hs
@@ -15,14 +15,19 @@ data Options = Options
     -- | When True, decoders are tolerant of missing list fields and
     -- | will default them to an empty list []. This is helpful in supporting
     -- | third-party APIs that remove empty fields from the response.
-    optionalListFields :: Bool
+    optionalListFields :: Bool,
+    -- | When True, decoders are tolerant of missing Maybe fields and
+    -- | will default them to Nothing. This is helpful in supporting
+    -- | third-party APIs that remove empty fields from the response.
+    optionalMaybeFields :: Bool
   }
 
 defaultOptions :: Options
 defaultOptions =
   Options
     { fieldLabelModifier = id,
-      optionalListFields = False
+      optionalListFields = False,
+      optionalMaybeFields = False
     }
 
 cr :: Format r r

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -161,14 +161,21 @@ instance HasDecoder ElmValue where
   render (ElmField name value) = do
     fieldModifier <- asks fieldLabelModifier
     optionalListFields' <- asks optionalListFields
+    optionalMaybeFields' <- asks optionalMaybeFields
     dv <- render value
     let isList = case value of
           (ElmPrimitiveRef (EList value'))
             | value' /= (ElmPrimitive EChar) -> True
           _ -> False
+    let isMaybe = case value of
+          ElmPrimitiveRef (EMaybe value') -> True
+          _ -> False
     if isList && optionalListFields'
       then return $ "|> optional" <+> dquotes (stext (fieldModifier name)) <+> dv <+> "[]"
-      else return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
+      else
+        if isMaybe && optionalMaybeFields'
+          then return $ "|> optional" <+> dquotes (stext (fieldModifier name)) <+> dv <+> "Nothing"
+          else return $ "|> required" <+> dquotes (stext (fieldModifier name)) <+> dv
   render ElmEmpty = pure (stext "")
 
 instance HasDecoderRef ElmPrimitive where

--- a/src/Elm/Decoder.hs
+++ b/src/Elm/Decoder.hs
@@ -168,7 +168,7 @@ instance HasDecoder ElmValue where
             | value' /= (ElmPrimitive EChar) -> True
           _ -> False
     let isMaybe = case value of
-          ElmPrimitiveRef (EMaybe value') -> True
+          ElmPrimitiveRef (EMaybe _) -> True
           _ -> False
     if isList && optionalListFields'
       then return $ "|> optional" <+> dquotes (stext (fieldModifier name)) <+> dv <+> "[]"

--- a/test/ExportSpec.hs
+++ b/test/ExportSpec.hs
@@ -428,7 +428,7 @@ toElmDecoderSpec =
               "%s"
             ]
         )
-        (defaultOptions {fieldLabelModifier = withPrefix "post", optionalListFields = True})
+        (defaultOptions {fieldLabelModifier = withPrefix "post", optionalListFields = True, optionalMaybeFields = True})
         (Proxy :: Proxy Post)
         "test/PostDecoderWithOptions.elm"
     it "toElmDecoderSource Position" $

--- a/test/PostDecoderWithOptions.elm
+++ b/test/PostDecoderWithOptions.elm
@@ -11,7 +11,7 @@ decodePost =
     succeed Post
         |> required "postId" int
         |> required "postName" string
-        |> required "postAge" (nullable float)
+        |> optional "postAge" (nullable float) Nothing
         |> optional "postComments" (list decodeComment) []
         |> required "postPromoted" (nullable decodeComment)
-        |> required "postAuthor" (nullable string)
+        |> optional "postAuthor" (nullable string) Nothing


### PR DESCRIPTION
Similar to #20 . It allows `Maybe` Haskell types to be treated as optionals. In Aeson we can choose whether to emit null or not.

Typesense explicitly ignore null values from the response which prevent use from fully using the generated elm decoders.